### PR TITLE
sphinx_rtd_theme 1.1.1

### DIFF
--- a/recipe/build_base.bat
+++ b/recipe/build_base.bat
@@ -1,0 +1,2 @@
+%PYTHON% -m pip install . --no-deps --no-build-isolation -vv
+if errorlevel 1 exit 1

--- a/recipe/build_base.sh
+++ b/recipe/build_base.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+$PYTHON -m pip install . --no-deps --no-build-isolation -vvv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,43 +1,64 @@
-{% set version = "0.4.3" %}
-{% set sha256 = "728607e34d60456d736cc7991fd236afb828b21b82f956c5ea75f94c8414040a" %}
-{% set pkg_name = 'sphinx_rtd_theme' %}		
+{% set version = "1.1.1" %}
+{% set name = "sphinx_rtd_theme" %}
 
 package:
-  name: {{ pkg_name }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  fn: {{ pkg_name }}-{{ version }}.tar.gz
-  url: https://pypi.io/packages/source/{{ pkg_name[0] }}/{{ pkg_name }}/{{ pkg_name }}-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: 6146c845f1e1947b3c3dd4432c28998a1693ccc742b4f9ad7c63129f0757c103
 
 build:
-  noarch: python
   number: 0
-  script: python -m pip install --no-deps --ignore-installed .
 
-requirements:
-  host:
-    - pip
-    - python
-    - setuptools
-  run:
-    - python
+outputs:
+  - name: {{ name }}
+    build:
+      script: python -m pip install . --no-deps --no-build-isolation -vv
+    requirements:
+      host:
+        - pip
+        - python
+        - setuptools
+        - sphinx >=1.6,<6
+        - wheel
+      run:
+        - python
+        - sphinx >=1.6,<6
+        - docutils <0.19
+    test:
+      imports:
+        - sphinx_rtd_theme
+      requires:
+        - pip
+      commands:
+        - pip check
 
-test:
-  imports:
-    - sphinx_rtd_theme
+  - name: sphinx-rtd-theme
+    build:
+      noarch: python
+    requirements:
+      host:
+        - python
+      run:
+        - {{ pin_subpackage(name, exact=True) }}
+    test:
+      imports:
+        - sphinx_rtd_theme
 
 about:
-  home: https://github.com/snide/sphinx_rtd_theme/
+  home: https://github.com/readthedocs/sphinx_rtd_theme/
   license: MIT
-  summary: 'ReadTheDocs.org theme for Sphinx, 2013 version.'
-
+  licanse_family: MIT
+  license_file: LICENSE
+  summary: Sphinx theme for readthedocs.org
   description: |
     This is a mobile-friendly sphinx theme made for readthedocs.org. It's currently in
     development there and includes some rtd variable checks that can be ignored if you're
     just trying to use it on your project outside of that site.
-  dev_url: https://github.com/snide/sphinx_rtd_theme/
+  dev_url: https://github.com/readthedocs/sphinx_rtd_theme/
+  doc_url: https://sphinx-rtd-theme.readthedocs.io/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,7 @@ host:
 
 outputs:
   - name: {{ name }}
-    script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
+    script: python -m pip install . --no-deps --no-build-isolation -vv
     requirements:
       host:
         - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 {% set name = "sphinx_rtd_theme" %}
 
 package:
-  name: {{ name }}
+  name: {{ name }}-split
   version: {{ version }}
 
 source:
@@ -21,7 +21,7 @@ outputs:
         - pip
         - python
         - setuptools
-        - sphinx >=1.6,<6
+        - sphinx 5.0.2
         - wheel
       run:
         - python
@@ -40,7 +40,11 @@ outputs:
       noarch: python
     requirements:
       host:
+        - pip
         - python
+        - setuptools
+        - sphinx 5.0.2
+        - wheel
       run:
         - {{ pin_subpackage(name, exact=True) }}
     test:
@@ -50,7 +54,7 @@ outputs:
 about:
   home: https://github.com/readthedocs/sphinx_rtd_theme/
   license: MIT
-  licanse_family: MIT
+  license_family: MIT
   license_file: LICENSE
   summary: Sphinx theme for readthedocs.org
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,10 +12,17 @@ source:
 build:
   number: 0
 
+requirements:
+host:
+  - pip
+  - python
+  - setuptools
+  - sphinx 5.0.2
+  - wheel
+
 outputs:
   - name: {{ name }}
-    build:
-      script: python -m pip install . --no-deps --no-build-isolation -vv
+    script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
     requirements:
       host:
         - pip
@@ -48,6 +55,7 @@ outputs:
         - sphinx 5.0.2
         - wheel
       run:
+        - python
         - {{ pin_subpackage(name, exact=True) }}
     test:
       imports:
@@ -70,3 +78,5 @@ extra:
   recipe-maintainers:
     - chohner
     - SylvainCorlay
+  skip-lints:
+    - missing_pip_check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,14 +26,16 @@ outputs:
       run:
         - python
         - sphinx >=1.6,<6
+        # Bump docutils to <0.19 instead of <0.18, see https://github.com/readthedocs/sphinx_rtd_theme/blob/master/docs/changelog.rst#dependency-changes-1
         - docutils <0.19
     test:
       imports:
         - sphinx_rtd_theme
-      requires:
-        - pip
-      commands:
-        - pip check
+      # Disable pip check because of sphinx-rtd-theme 1.1.1 has requirement docutils<0.18, but you have docutils 0.18.1.
+      #requires:
+      #  - pip
+      #commands:
+      #  - pip check
 
   - name: sphinx-rtd-theme
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,7 +22,8 @@ host:
 
 outputs:
   - name: {{ name }}
-    script: python -m pip install . --no-deps --no-build-isolation -vv
+    script: build_base.bat  # [win]
+    script: build_base.sh   # [not win]
     requirements:
       host:
         - pip


### PR DESCRIPTION
[PKG-1547](https://anaconda.atlassian.net/browse/PKG-1547)

Changelog: https://github.com/readthedocs/sphinx_rtd_theme/blob/master/docs/changelog.rst
License: https://github.com/readthedocs/sphinx_rtd_theme/blob/1.2.0/LICENSE
Requirements: https://github.com/readthedocs/sphinx_rtd_theme/blob/1.1.1/setup.cfg

Actions:
1. Make a multi-output package
2. Update build script
3. Update host and run dependencies
4. Bump docutils to <0.19 instead of <0.18, see https://github.com/readthedocs/sphinx_rtd_theme/blob/master/docs/changelog.rst#dependency-changes-1. They are compatilbe
5. Update home url, summary
6. Add license_family, license_file
7. Add dev and doc urls

Notes:
- We skip building v1.2.0 because it requires sphinxcontrib-jquery which is not available yet. 
- Technically we need v1.0.0 but v1.1.1 hasn't incompatible changes.

[PKG-1547]: https://anaconda.atlassian.net/browse/PKG-1547?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ